### PR TITLE
Add autoloading via composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
   },
   "scripts": {
     "php_src": "phpcs --standard=phpcs.xml --ignore=*vendor/* -s -p --colors ./"
+  },
+  "autoload" : {
+      "psr-4" : {
+          "jblond\\Apache_Log_Parser\\" : "."
+      }
   }
 }

--- a/error_log.php
+++ b/error_log.php
@@ -2,8 +2,7 @@
 
 use jblond\Apache_Log_Parser\ApacheErrorLogParser;
 
-require 'ApacheLogParser.php';
-require 'ApacheErrorLogParser.php';
+require 'vendor/autoload.php';
 
 $log_parser = new ApacheErrorLogParser("C:\\Users\\jblond\\Apache24\\logs\\error.log");
 echo $log_parser->output();


### PR DESCRIPTION
I noticed this package on Packagist but when I downloaded it to evaluate it I realised you didn't set up any autoloading. So here's basic autoloading set up and the error_log.php example file updated to use the composer autoload file.